### PR TITLE
Use luaossl instead of luacrypto.

### DIFF
--- a/jwt-0.5-2.rockspec
+++ b/jwt-0.5-2.rockspec
@@ -14,7 +14,7 @@ description = {
 dependencies = {
   "lua >= 5.1",
   "busted >= 1.7-1",
-  "luacrypto >= 0.3.2-1",
+  "luaossl >= 20151221-0",
   "lua-cjson-ol >= 1.0-1",
   "basexx >= 0.2.0-0"
 }

--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -47,48 +47,105 @@ describe("JWT spec", function()
       test = "test",
       empty={},
     }
-    local keyPair = pkey.new{type = "rsa", bits=512}
-    local token, _ = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
-    local decodedClaims = jwt.decode(token, {keys = {public = keyPair}})
+    local keys = {
+      private =
+[[-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
+Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
+dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
+CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
+vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
+Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
+3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
+-----END RSA PRIVATE KEY-----]],
+      public =
+[[-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
+D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
+-----END PUBLIC KEY-----]],
+    }
+    local token, _ = jwt.encode(claims, {alg = "RS256", keys = { private = keys.private }})
+    local decodedClaims = jwt.decode(token, {keys = { public = keys.public }})
     assert.are.same(claims, decodedClaims)
   end)
 
   if crypto then
-    it("it can encode/decode a signed plain text token with alg=RS256 (using luacrypto)", function()
+    it("it cannot encode/decode a signed plain text token with alg=RS256 (using luacrypto pkey)", function()
       local claims = {
         test = "test",
         empty={},
       }
-      local keyPair = crypto.pkey.generate("rsa", 512)
-      local token, _ = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
-      local decodedClaims = jwt.decode(token, {keys = {public = keyPair}})
-      assert.are.same(claims, decodedClaims)
+      local key = crypto.pkey.generate("rsa", 512)
+      local private_key =
+[[-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
+Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
+dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
+CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
+vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
+Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
+3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
+-----END RSA PRIVATE KEY-----]]
+      local token, _ = jwt.encode(claims, {alg = "RS256", keys = { private = private_key }})
+      assert.has.error (function ()
+        jwt.encode(claims, {alg = "RS256", keys = {private = key}})
+      end)
+      assert.has.error (function ()
+        jwt.decode(token, {keys = {public = key}})
+      end)
     end)
   end
+
+  it("it cannot encode/decode a signed plain text token with alg=RS256 (using luaossl pkey)", function()
+    local claims = {
+      test = "test",
+      empty={},
+    }
+    local key = pkey.new{type = "rsa", bits=512}
+    local private_key =
+[[-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
+Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
+dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
+CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
+vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
+Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
+3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
+-----END RSA PRIVATE KEY-----]]
+    local token, _ = jwt.encode(claims, {alg = "RS256", keys = { private = private_key }})
+    assert.has.error (function ()
+      jwt.encode(claims, {alg = "RS256", keys = {private = key}})
+    end)
+    assert.has.error (function ()
+      jwt.decode(token, {keys = {public = key}})
+    end)
+  end)
 
   it("it cannot encode/decode a signed plain text token with alg=RS256 and an incorrect key", function()
     local claims = {
       test = "test",
     }
-    local keyPair = pkey.new{type="rsa", bits=512}
-    local badPair = pkey.new{type="rsa", bits=512}
-    local token = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
-    local decodedClaims = jwt.decode(token, {keys = {public = badPair}})
-    assert.has_error(function() assert.are.same(claims, decodedClaims) end)
+    local keys = {
+      private =
+[[-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
+Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
+dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
+CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
+vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
+Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
+3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
+-----END RSA PRIVATE KEY-----]],
+      public =
+[[-----BEGIN PUBLIC KEY-----
+MQwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
+D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
+-----END PUBLIC KEY-----]],
+    }
+    local token = jwt.encode(claims, {alg = "RS256", keys = { private = keys.private }})
+    local decodedClaims = jwt.decode(token, {keys = { public = keys.public }})
+    assert.are_not.same(claims, decodedClaims)
   end)
-
-  if crypto then
-    it("it cannot encode/decode a signed plain text token with alg=RS256 and an incorrect key (using luacrypto)", function()
-      local claims = {
-        test = "test",
-      }
-      local keyPair = crypto.pkey.generate("rsa", 512)
-      local badPair = crypto.pkey.generate("rsa", 512)
-      local token = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
-      local decodedClaims = jwt.decode(token, {keys = {public = badPair}})
-      assert.has_error(function() assert.are.same(claims, decodedClaims) end)
-    end)
-  end
 
   it("can verify a signature", function()
     local token = "eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJhOGZjZTFkZi1iNGFlLTRjNDEtYmFjNi1iNWJiZjI4MGMyOWMiLCJzdWIiOiI3YmZjNThlYy03N2RkLTQ4NzQtYmViZC1iYTg0MTAzMDEyNzkiLCJzY29wZSI6WyJvYXV0aC5hcHByb3ZhbHMiLCJvcGVuaWQiXSwiY2xpZW50X2lkIjoibG9naW4iLCJjaWQiOiJsb2dpbiIsImdyYW50X3R5cGUiOiJwYXNzd29yZCIsInVzZXJfaWQiOiI3YmZjNThlYy03N2RkLTQ4NzQtYmViZC1iYTg0MTAzMDEyNzkiLCJ1c2VyX25hbWUiOiJhZG1pbkBmb3Jpby5jb20iLCJlbWFpbCI6ImFkbWluQGZvcmlvLmNvbSIsImlhdCI6MTM5ODkwNjcyNywiZXhwIjoxMzk4OTQ5OTI3LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojk3NjMvdWFhL29hdXRoL3Rva2VuIiwiYXVkIjpbIm9hdXRoIiwib3BlbmlkIl19.xOa5ZpXksgoaA_XJ3yHMjlLcbSoM6XJy-e60zfyP7bRmu0EKEGZdZrl2iJVh6OTIn8z6UuvcY282C1A5LtRgpir4wqhIrphd-Mi9gfxra0pJvtydd4XqVpuNdW7GDaC43VXpvUtetmfn-YAo2jkD9G22mUuT2sFdt5NqFL7Rk4tVRILes73OWxfQpuoReWvRBik-sJXxC9ADmTuzR36OvomIrso42R8aufU2ku_zPve8IhYLvn3vHmYCt0zNZkX-jSV8YtGodr9V-dKs9na41YvGp2UxkBcV7LKoGSRELSSNJ8JLF-bjO3zYSSbT42-yeHeKfoWAeP6R7S_0c_AYRA"
@@ -115,7 +172,7 @@ EQIDAQAB
 
   it("can encode and decode rs256", function()
     local keys = {
-      private = pkey.new(
+      private =
 [[-----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
 Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
@@ -124,12 +181,12 @@ CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
 vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
 Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
 3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
------END RSA PRIVATE KEY-----]]),
-      public = pkey.new(
+-----END RSA PRIVATE KEY-----]],
+      public =
 [[-----BEGIN PUBLIC KEY-----
 MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
 D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
------END PUBLIC KEY-----]]),
+-----END PUBLIC KEY-----]],
     }
     local claims = {
       test = "test",
@@ -141,39 +198,9 @@ D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
     assert.are.same(claims, decodedClaims)
   end)
 
-  if crypto then
-    it("can encode and decode rs256 (using luacrypto)", function()
-      local keys = {
-        private = crypto.pkey.from_pem(
-[[-----BEGIN RSA PRIVATE KEY-----
-MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
-Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
-dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
-CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
-vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
-Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
-3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
------END RSA PRIVATE KEY-----]], true),
-        public = crypto.pkey.from_pem(
-[[-----BEGIN PUBLIC KEY-----
-MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
-D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
------END PUBLIC KEY-----]], false),
-        }
-        local claims = {
-          test = "test",
-          longClaim = "iubvn1oubv91henvicuqnw93bn19u  ndij npkhabsdvlb23iou4bijbandlivubhql3ubvliuqwdbnvliuqwhv9ulqbhiulbiluabsdvuhbq9urbv9ubqubxuvbu9qbdshvuhqniuhv9uhbfq9uhr89hqu9ebnv9uqhu9rbvp9843$#BVCo²¸´no414i"
-        }
-        local token = jwt.encode(claims, {alg = "RS256", keys = keys})
-        local decodedClaims, err = jwt.decode(token, {keys = keys})
-        if not decodedClaims then error(err) end
-        assert.are.same(claims, decodedClaims)
-      end)
-    end
-
     it("does not throw an error when key is invalid in rs256", function()
     local keys = {
-      private = pkey.new(
+      private =
 [[-----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
 Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
@@ -182,12 +209,12 @@ CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
 vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
 Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
 3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
------END RSA PRIVATE KEY-----]]),
-      public = pkey.new(
+-----END RSA PRIVATE KEY-----]],
+      public =
 [[-----BEGIN PUBLIC KEY-----
 MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
 D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
------END PUBLIC KEY-----]]),
+-----END PUBLIC KEY-----]],
     }
     local invalid_key = "a really invalid key"
     local data = {

--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -143,4 +143,16 @@ D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
       assert.is_not_nil(err)
     end)
   end)
+
+  it("throws an error when failing to generate a signature", function()
+    local invalid_key = "a really invalid key"
+    local data = {
+      test = "test",
+    }
+    assert.has_error(function ()
+      local token, err = jwt.encode(data, {alg = "RS256", keys = { private = invalid_key }})
+      assert.is_nil(token)
+      assert.is_not_nil(err)
+    end)
+  end)
 end)

--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -113,4 +113,34 @@ D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
     if not decodedClaims then error(err) end
     assert.are.same(claims, decodedClaims)
   end)
+
+  it("does not throw an error when key is invalid in rs256", function()
+    local keys = {
+      private = pkey.new(
+[[-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
+Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
+dyeqHYF0UD5vtHLxs/BWLPI2lZO0e6ixFNI4uIuatBox1Zbzt1TSy8T09Slt4tNL
+CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
+vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
+Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
+3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
+-----END RSA PRIVATE KEY-----]]),
+      public = pkey.new(
+[[-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
+D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
+-----END PUBLIC KEY-----]]),
+    }
+    local invalid_key = "a really invalid key"
+    local data = {
+      test = "test",
+    }
+    local token = jwt.encode(data, {alg = "RS256", keys = keys})
+    assert.has.no.error(function ()
+      local result, err = jwt.decode(token, {keys = {public = invalid_key }})
+      assert.is_nil(result)
+      assert.is_not_nil(err)
+    end)
+  end)
 end)

--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -1,7 +1,7 @@
 describe("JWT spec", function()
 
-  local jwt = require 'jwt'
-  local crypto = require 'crypto'
+  local jwt  = require 'jwt'
+  local pkey = require 'openssl.pkey'
   local plainJwt = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ"
 
   it("can decode a plain text token", function()
@@ -46,7 +46,7 @@ describe("JWT spec", function()
       test = "test",
       empty={},
     }
-    local keyPair = crypto.pkey.generate("rsa", 512)
+    local keyPair = pkey.new{type = "rsa", bits=512}
     local token, err = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
     local decodedClaims = jwt.decode(token, {keys = {public = keyPair}})
     assert.are.same(claims, decodedClaims)
@@ -56,8 +56,8 @@ describe("JWT spec", function()
     local claims = {
       test = "test",
     }
-    local keyPair = crypto.pkey.generate("rsa", 512)
-    local badPair = crypto.pkey.generate("rsa", 512)
+    local keyPair = pkey.new{type="rsa", bits=512}
+    local badPair = pkey.new{type="rsa", bits=512}
     local token = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
     local decodedClaims = jwt.decode(token, {keys = {public = badPair}})
     assert.has_error(function() assert.are.same(claims, decodedClaims) end)
@@ -88,7 +88,7 @@ EQIDAQAB
 
   it("can encode and decode rs256", function()
     local keys = {
-      private = crypto.pkey.from_pem(
+      private = pkey.new(
 [[-----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/D5z2A7KPYXUgUP0jd5yL
 Z7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQJBAJYXWNmw7Cgbkk1+v3C0
@@ -97,12 +97,12 @@ CAECIQD6PHDGtKXcI2wUSvh4y8y7XfvwlwRPU2AzWZ1zvOCbbQIhANzgMpUNOZL2
 vakju4sal1yZeXUWO8FurmsAyotAx9tBAiB2oQKh4PAkXZKWSDhlI9CqHtMaaq17
 Yb5geaKARNGCPQIgILYrh5ufzT4xtJ0QJ3fWtuYb8NVMIEeuGTbSyHDdqIECIQDZ
 3LNCyR2ykwetc6KqbQh3W4VkuatAQgMv5pNdFLrfmg==
------END RSA PRIVATE KEY-----]], true),
-      public = crypto.pkey.from_pem(
+-----END RSA PRIVATE KEY-----]]),
+      public = pkey.new(
 [[-----BEGIN PUBLIC KEY-----
 MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANfnFz7xPmYVdJxZE7sQ5quh/XUzB5y/
 D5z2A7KPYXUgUP0jd5yLZ7+pVBcFSUm5AZXJLXH4jPVOXztcmiu4ta0CAwEAAQ==
------END PUBLIC KEY-----]], false),
+-----END PUBLIC KEY-----]]),
     }
     local claims = {
       test = "test",

--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -48,7 +48,7 @@ describe("JWT spec", function()
       empty={},
     }
     local keyPair = pkey.new{type = "rsa", bits=512}
-    local token, err = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
+    local token, _ = jwt.encode(claims, {alg = "RS256", keys = {private = keyPair}})
     local decodedClaims = jwt.decode(token, {keys = {public = keyPair}})
     assert.are.same(claims, decodedClaims)
   end)

--- a/src/jwt/jws.lua
+++ b/src/jwt/jws.lua
@@ -27,12 +27,16 @@ data.verify = {
   ['HS384'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha512'):final (data)) end,
   ['RS256'] = function(data, signature, key)
-    local pubkey
-    if type(key) == 'string' then pubkey = pkey.new(key)
-    elseif type(key) == 'table' then pubkey = pkey.new(key.public)
-    elseif type(key) == 'userdata' then pubkey = key
-    end
-    return pubkey:verify(signature, digest.new('sha256'):update(data))
+    local ok, result = pcall(function()
+      local pubkey
+      if type(key) == 'string' then pubkey = pkey.new(key)
+      elseif type(key) == 'userdata' then pubkey = key
+      else assert (false)
+      end
+      return pubkey:verify(signature, digest.new('sha256'):update(data))
+    end)
+    if not ok then return nil, result end
+    return result
   end,
 }
 

--- a/src/jwt/jws.lua
+++ b/src/jwt/jws.lua
@@ -20,6 +20,10 @@ data.sign = {
   ['HS384'] = function(data, key) return tohex(hmac.new(key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, key) return tohex(hmac.new(key, 'sha512'):final (data)) end,
   ['RS256'] = function(data, key)
+    local mt = getmetatable(key)
+    if type(mt) == "string" and mt:match "^LuaCrypto" then
+      key = pkey.new (key:to_pem(true))
+    end
     local ok, result = pcall(function()
       return key:sign(digest.new('sha256'):update(data))
     end)
@@ -33,6 +37,10 @@ data.verify = {
   ['HS384'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha512'):final (data)) end,
   ['RS256'] = function(data, signature, key)
+    local mt = getmetatable(key)
+    if type(mt) == "string" and mt:match "^LuaCrypto" then
+      key = pkey.new (key:to_pem())
+    end
     local ok, result = pcall(function()
       local pubkey
       if type(key) == 'string' then pubkey = pkey.new(key)

--- a/src/jwt/jws.lua
+++ b/src/jwt/jws.lua
@@ -20,12 +20,9 @@ data.sign = {
   ['HS384'] = function(data, key) return tohex(hmac.new(key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, key) return tohex(hmac.new(key, 'sha512'):final (data)) end,
   ['RS256'] = function(data, key)
-    local mt = getmetatable(key)
-    if type(mt) == "string" and mt:match "^LuaCrypto" then
-      key = pkey.new (key:to_pem(true))
-    end
+    assert(type(key) == "string")
     local ok, result = pcall(function()
-      return key:sign(digest.new('sha256'):update(data))
+      return pkey.new(key):sign(digest.new('sha256'):update(data))
     end)
     if not ok then return nil, result end
     return result
@@ -37,17 +34,9 @@ data.verify = {
   ['HS384'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha512'):final (data)) end,
   ['RS256'] = function(data, signature, key)
-    local mt = getmetatable(key)
-    if type(mt) == "string" and mt:match "^LuaCrypto" then
-      key = pkey.new (key:to_pem())
-    end
+    assert(type(key) == "string")
     local ok, result = pcall(function()
-      local pubkey
-      if type(key) == 'string' then pubkey = pkey.new(key)
-      elseif type(key) == 'userdata' then pubkey = key
-      else assert (false)
-      end
-      return pubkey:verify(signature, digest.new('sha256'):update(data))
+      return pkey.new(key):verify(signature, digest.new('sha256'):update(data))
     end)
     if not ok then return nil, result end
     return result

--- a/src/jwt/jws.lua
+++ b/src/jwt/jws.lua
@@ -19,7 +19,13 @@ data.sign = {
   ['HS256'] = function(data, key) return tohex(hmac.new(key, 'sha256'):final (data)) end,
   ['HS384'] = function(data, key) return tohex(hmac.new(key, 'sha384'):final (data)) end,
   ['HS512'] = function(data, key) return tohex(hmac.new(key, 'sha512'):final (data)) end,
-  ['RS256'] = function(data, key) return key:sign(digest.new('sha256'):update(data)) end,
+  ['RS256'] = function(data, key)
+    local ok, result = pcall(function()
+      return key:sign(digest.new('sha256'):update(data))
+    end)
+    if not ok then return nil, result end
+    return result
+  end,
 }
 
 data.verify = {


### PR DESCRIPTION
The `luacrypto` module does not seem to be maintained anymore (mkottman/luacrypto#39). Its current version on luarocks does not accept Lua 5.3, which is annoying.
This pull request is a proposal to use `luaossl` instead, as it is compatible with newer version of Lua.

**Warning:** i am a totally newbie in openssl, so the proposed fixes might be totally wrong. I just checked that all tests still pass. Moreover, the `luaossl` module can throw errors. I did not add code to catch them.