### PR TITLE
Token comparison is not reliable

### DIFF
--- a/spec/jwt_spec.lua
+++ b/spec/jwt_spec.lua
@@ -19,8 +19,8 @@ describe("JWT spec", function()
       ["http://example.com/is_root"] = true
     }
     local token = jwt.encode(claim)
-    local token2 = jwt.encode(jwt.decode(plainJwt))
-    assert(token == token2)
+    assert.are.same(jwt.decode(token), claim)
+    assert.are.same(jwt.decode(plainJwt), claim)
   end)
 
   it("it can encode/decode a signed plain text token with alg=HS256", function()

--- a/src/jwt.lua
+++ b/src/jwt.lua
@@ -38,7 +38,9 @@ local function header(options)
       sub = options.sub,
     }
   end
-  return {}
+  return {
+    alg = "none",
+  }
 end
 
 function data.encode(claims, options)

--- a/src/jwt/plain.lua
+++ b/src/jwt/plain.lua
@@ -5,7 +5,7 @@ json.encode_empty_table('array')
 local data    = {}
 
 function data:encode(header, claims)
-  return basexx.to_url64(json.encode(claims))
+  return basexx.to_url64(json.encode(header)) .. "." .. basexx.to_url64(json.encode(claims))
 end
 
 function data:decode(header, str, options)


### PR DESCRIPTION
The test "can encode a plain text token" sometimes fails (run it a big number of times with different lua interpreters to see the failure), because token encoding relies on `cjson.encode`. This function does not guarantee to always sort keys in the same order, leading to different encodings, and thus different tokens.

The proposed fix compares decoded tokens instead of token strings. It also adds a header to plain tokens (with `alg=none`), that was missing and thus made tokens not decodable. For instance: `jwt.decode(jwt.encode(data))` raised an error.