### PR TITLE
added token date checks & signature is now forced to lowercase hex before validation.

### DIFF
--- a/src/jwt.lua
+++ b/src/jwt.lua
@@ -2,6 +2,7 @@ local meta    = {}
 local data    = {}
 
 local json    = require 'cjson'
+local json_safe = require 'cjson.safe'
 json.encode_empty_table('array')
 local basexx  = require 'basexx'
 local jws     = require 'jwt.jws'
@@ -55,7 +56,8 @@ function data.decode(str, options)
   if not str then return nil, "Parameter 1 cannot be nil" end
   local dotFirst = str:find("%.")
   if not dotFirst then return nil, "Invalid token" end
-  local header = json.decode((basexx.from_url64(str:sub(1,dotFirst-1))))
+  local header, err = json_safe.decode((basexx.from_url64(str:sub(1,dotFirst-1))))
+  if (header == nil) then return nil, err end
 
   return getJwt(header):decode(header, str, options)
 end


### PR DESCRIPTION
For some reason, i couldn't get token verification to work as-is..
 signature = basexx.from_url64(str:sub(dotSecond+1)) was returning binary, but 
 ['HS256'] = function(data, signature, key) return signature == tohex(hmac.new (key, 'sha256'):final (data)) end, was returning lowercase hex.
So, forced extracted message signature to lowercase hex.

Also, added token date (nbf, and exp) checks if they are defined within the token.

Hope this helps..
