### PR TITLE
Fix digest when using luaossl

### DIFF
--- a/src/jwt/utils.lua
+++ b/src/jwt/utils.lua
@@ -47,17 +47,17 @@ if prequire "openssl.digest" then -- luaossl
 
   DIGEST = {
     SHA256 = function(data, hex)
-      local s = digest.new(key, 'sha256'):update (data)
+      local s = digest.new('sha256'):update (data)
       if hex then s = tohex(s) end
       return s
     end;
     SHA384 = function(data, hex)
-      local s = digest.new(key, 'sha384'):update (data)
+      local s = digest.new('sha384'):update (data)
       if hex then s = tohex(s) end
       return s
     end;
     SHA512 = function(data, hex)
-      local s = digest.new(key, 'sha512'):update (data)
+      local s = digest.new('sha512'):update (data)
       if hex then s = tohex(s) end
       return s
     end;


### PR DESCRIPTION
Looks like there was a typo when implementing the digest creation functions when using `luaossl`.  

From http://25thandclement.com/~william/projects/luaossl.pdf:
![image](https://user-images.githubusercontent.com/1014577/57025492-40d75180-6c05-11e9-855d-69752a350ef3.png)
